### PR TITLE
Upgrade phel to require master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "phel-lang/phel-lang": "^0.7"
+        "phel-lang/phel-lang": "dev-master"
     },
     "scripts": {
         "test": "vendor/bin/phel test"


### PR DESCRIPTION
## 📚  Description

I am experimenting with something, and I need some latest features from phel while using this package. Can we upgrade it for now? We decided to move it to the official repo, so I think it wouldn't be an issue to do this.